### PR TITLE
Turned the SQL Query into a resource file

### DIFF
--- a/src/main/resources/sql-queries/agent_installs_label_matching_query.sql
+++ b/src/main/resources/sql-queries/agent_installs_label_matching_query.sql
@@ -1,0 +1,55 @@
+SELECT
+   agent_installs.id
+FROM
+   agent_installs JOIN agent_install_label_selectors AS ail
+WHERE
+   agent_installs.id = ail.agent_install_id
+   AND agent_installs.id IN
+   (
+      SELECT
+         agent_install_id
+      FROM
+         agent_install_label_selectors
+      WHERE agent_installs.id IN
+         (
+            SELECT
+               id
+            FROM
+               agent_installs
+            WHERE
+               tenant_id = :tenantId
+         )
+         AND agent_installs.id IN
+         (
+            SELECT
+               search_labels.agent_install_id
+            FROM
+               (
+                  SELECT
+                     agent_install_id,
+                     COUNT(*) AS count
+                  FROM
+                     agent_install_label_selectors
+                  GROUP BY
+                     agent_install_id
+               )
+               AS total_labels
+               JOIN
+                  (
+                     SELECT
+                        agent_install_id,
+                        COUNT(*) AS count
+                     FROM
+                        agent_install_label_selectors
+                     WHERE %s
+                     GROUP BY agent_install_id
+                  )
+                  AS search_labels
+            WHERE
+               total_labels.agent_install_id = search_labels.agent_install_id
+               AND search_labels.count >= total_labels.count
+            GROUP BY search_labels.agent_install_id
+         )
+   )
+ORDER BY
+   agent_installs.id


### PR DESCRIPTION
#Resolves

https://jira.rax.io/browse/SALUS-480

#What

This is meant to simplify reading and debugging of any of the actual SQL queries we need to write for Resource Management

#How

This migrates the StringBuilder approach into just a static .sql file. Most of the query is static with only a few locations needing parameters being set. The static query does utilize a String.Format tag to allow us to inject the complex label matching portion of the query into the middle of this template.

#How to test

Run the unit tests. We weren't testing the query in the first place so the tests dont need to change. We just need to make sure they still return the same.

#Why

I considered removing all of the string building from java and building the whole thing with a jmustache template. Ultimately this is for readability of the query and ease of debugging. I didn't think that jmustache would help with the readability and it actually would add a bit of weirdness because we still need to make sure we have cleansed our inputs by passing everything in through parameters to jdbc.