### PR TITLE
added exception handling for jdbc and kafka

### DIFF
--- a/src/main/java/com/rackspace/salus/acm/services/BoundEventSender.java
+++ b/src/main/java/com/rackspace/salus/acm/services/BoundEventSender.java
@@ -64,9 +64,7 @@ public class BoundEventSender {
       final String key = KafkaMessageKeyBuilder.buildMessageKey(event);
       try {
         kafkaTemplate.send(topic, key, event).get();
-      } catch (InterruptedException e) {
-        throw new RuntimeKafkaException(e);
-      } catch (ExecutionException e) {
+      } catch (InterruptedException|ExecutionException e) {
         throw new RuntimeKafkaException(e);
       }
     }

--- a/src/main/java/com/rackspace/salus/acm/services/BoundEventSender.java
+++ b/src/main/java/com/rackspace/salus/acm/services/BoundEventSender.java
@@ -16,12 +16,14 @@
 
 package com.rackspace.salus.acm.services;
 
+import com.rackspace.salus.common.errors.RuntimeKafkaException;
 import com.rackspace.salus.common.messaging.KafkaMessageKeyBuilder;
 import com.rackspace.salus.common.messaging.KafkaTopicProperties;
 import com.rackspace.salus.telemetry.messaging.AgentInstallChangeEvent;
 import com.rackspace.salus.telemetry.messaging.OperationType;
 import com.rackspace.salus.telemetry.model.AgentType;
 import java.util.List;
+import java.util.concurrent.ExecutionException;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.kafka.core.KafkaTemplate;
@@ -60,7 +62,13 @@ public class BoundEventSender {
 
       log.debug("Sending event={} on topic={}", event, topic);
       final String key = KafkaMessageKeyBuilder.buildMessageKey(event);
-      kafkaTemplate.send(topic, key, event);
+      try {
+        kafkaTemplate.send(topic, key, event).get();
+      } catch (InterruptedException e) {
+        throw new RuntimeKafkaException(e);
+      } catch (ExecutionException e) {
+        throw new RuntimeKafkaException(e);
+      }
     }
   }
 }

--- a/src/main/java/com/rackspace/salus/acm/web/controller/RestExceptionHandler.java
+++ b/src/main/java/com/rackspace/salus/acm/web/controller/RestExceptionHandler.java
@@ -68,13 +68,12 @@ public class RestExceptionHandler extends
   @ExceptionHandler({JDBCException.class})
   public ResponseEntity<?> handleJDBCException(
       HttpServletRequest request) {
-    return respondWith(request, HttpStatus.INTERNAL_SERVER_ERROR, ResponseMessages.jdbcExceptionMessage);
+    return respondWith(request, HttpStatus.SERVICE_UNAVAILABLE, ResponseMessages.jdbcExceptionMessage);
   }
 
   @ExceptionHandler({RuntimeKafkaException.class})
   public ResponseEntity<?> handleKafkaExceptions(
       HttpServletRequest request) {
-    return respondWith(request, HttpStatus.INTERNAL_SERVER_ERROR, ResponseMessages.kafkaExceptionMessage);
+    return respondWith(request, HttpStatus.SERVICE_UNAVAILABLE, ResponseMessages.kafkaExceptionMessage);
   }
-
 }

--- a/src/main/java/com/rackspace/salus/acm/web/controller/RestExceptionHandler.java
+++ b/src/main/java/com/rackspace/salus/acm/web/controller/RestExceptionHandler.java
@@ -16,9 +16,12 @@
 
 package com.rackspace.salus.acm.web.controller;
 
+import com.rackspace.salus.common.errors.ResponseMessages;
+import com.rackspace.salus.common.errors.RuntimeKafkaException;
 import com.rackspace.salus.telemetry.errors.AlreadyExistsException;
 import com.rackspace.salus.telemetry.model.NotFoundException;
 import javax.servlet.http.HttpServletRequest;
+import org.hibernate.JDBCException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.web.servlet.error.ErrorAttributes;
 import org.springframework.dao.DataIntegrityViolationException;
@@ -60,6 +63,18 @@ public class RestExceptionHandler extends
   public ResponseEntity<?> handleAlreadyExists(
       HttpServletRequest request) {
     return respondWith(request, HttpStatus.UNPROCESSABLE_ENTITY);
+  }
+
+  @ExceptionHandler({JDBCException.class})
+  public ResponseEntity<?> handleJDBCException(
+      HttpServletRequest request) {
+    return respondWith(request, HttpStatus.INTERNAL_SERVER_ERROR, ResponseMessages.jdbcExceptionMessage);
+  }
+
+  @ExceptionHandler({RuntimeKafkaException.class})
+  public ResponseEntity<?> handleKafkaExceptions(
+      HttpServletRequest request) {
+    return respondWith(request, HttpStatus.INTERNAL_SERVER_ERROR, ResponseMessages.kafkaExceptionMessage);
   }
 
 }


### PR DESCRIPTION
# Resolves

https://jira.rax.io/browse/SALUS-433

# What

This PR is trying to catch the error when the API nodes are up but a service behind the API node isn't. 

# How

I am catching the particular error that gets thrown when another service isn't running. 

## How to test

Start this service after starting all of the docker containers. 
After this has started shut down mysql.
Send a creation request in.
Bring mysql back up and shut down kafka.
send the same creation request.

# Why

For unknown reasons Spring Boot doesn't seem to appreciate using the configuration options for not including the exception or the stack trace.

Instead I decided to utilize the pattern we are already using for catching exceptions and responding with HTTP status codes to give a friendly message.