### PR TITLE
Adam9500/salus 606 or label match

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -17,38 +17,39 @@ steps:
     dir: /root
     entrypoint: bash
     args:
-    - -c
-    - |
-      (
-        gsutil cp gs://${_GCS_CACHE_BUCKET}/${_SALUS_PROJECT}-m2-cache.tar.gz /tmp/m2-cache.tar.gz &&
-        tar -xzf /tmp/m2-cache.tar.gz
-      ) || echo 'Cache not found'
+      - -c
+      - |
+        (
+          gsutil cp gs://${_GCS_CACHE_BUCKET}/${_SALUS_PROJECT}-m2-cache.tar.gz /tmp/m2-cache.tar.gz &&
+          tar -xzf /tmp/m2-cache.tar.gz
+        ) || echo 'Cache not found'
     volumes:
-    - name: user.home
-      path: /root
+      - name: user.home
+        path: /root
 
-  - id: DEPLOY
+  - id: VERIFY
     name: 'gcr.io/cloud-builders/mvn'
-    args: ['-B', 'deploy', '-s', '.mvn/settings.xml']
+    args: ['-B', 'verify', '-s', '.mvn/settings.xml']
     volumes:
-    - name: user.home
-      path: /root
+      - name: user.home
+        path: /root
 
   # Saves the files to the GCS cache.
   - id: PUSH_UP_CACHE
     waitFor:
-    - DEPLOY
+      - VERIFY
     name: gcr.io/cloud-builders/gsutil
     dir: /root
     entrypoint: bash
     # Caches the local Maven repository.
     args:
-    - -c
-    - |
-      set -ex
-      tar -czf /tmp/m2-cache.tar.gz .m2 &&
-      gsutil cp /tmp/m2-cache.tar.gz gs://${_GCS_CACHE_BUCKET}/${_SALUS_PROJECT}-m2-cache.tar.gz
+      - -c
+      - |
+        set -ex
+        tar -czf /tmp/m2-cache.tar.gz .m2 &&
+        gsutil cp /tmp/m2-cache.tar.gz gs://${_GCS_CACHE_BUCKET}/${_SALUS_PROJECT}-m2-cache.tar.gz
     volumes:
-    - name: user.home
-      path: /root
+      - name: user.home
+        path: /root
+
 

--- a/src/main/java/com/rackspace/salus/acm/services/AgentInstallService.java
+++ b/src/main/java/com/rackspace/salus/acm/services/AgentInstallService.java
@@ -21,6 +21,7 @@ import com.rackspace.salus.common.util.SpringResourceUtils;
 import com.rackspace.salus.telemetry.entities.AgentInstall;
 import com.rackspace.salus.telemetry.entities.AgentRelease;
 import com.rackspace.salus.telemetry.entities.BoundAgentInstall;
+import com.rackspace.salus.telemetry.model.LabelSelectorMethod;
 import com.rackspace.salus.telemetry.repositories.AgentInstallRepository;
 import com.rackspace.salus.telemetry.repositories.AgentReleaseRepository;
 import com.rackspace.salus.telemetry.repositories.BoundAgentInstallRepository;
@@ -101,7 +102,8 @@ public class AgentInstallService {
     final AgentInstall agentInstall = new AgentInstall()
         .setAgentRelease(agentRelease)
         .setLabelSelector(in.getLabelSelector())
-        .setTenantId(tenantId);
+        .setTenantId(tenantId)
+        .setLabelSelectorMethod(in.getLabelSelectorMethod());
 
     final AgentInstall saved = agentInstallRepository.save(agentInstall);
 
@@ -208,7 +210,7 @@ public class AgentInstallService {
 
   private void bindInstallToResources(AgentInstall agentInstall) {
     final List<ResourceDTO> resources = resourceApi
-        .getResourcesWithLabels(agentInstall.getTenantId(), agentInstall.getLabelSelector());
+        .getResourcesWithLabels(agentInstall.getTenantId(), agentInstall.getLabelSelector(), agentInstall.getLabelSelectorMethod());
 
     log.debug("Found resources={} matching selector of agentInstall={}", resources, agentInstall);
 

--- a/src/main/java/com/rackspace/salus/acm/services/AgentInstallService.java
+++ b/src/main/java/com/rackspace/salus/acm/services/AgentInstallService.java
@@ -206,8 +206,6 @@ public class AgentInstallService {
 
     monitorIds.addAll(monitorOrIds);
 
-    //combine the lists of UUID's here
-
     // use JPA to retrieve and resolve the entities and then convert Iterable result to list
     final ArrayList<AgentInstall> results = new ArrayList<>();
     for (AgentInstall agentInstall : agentInstallRepository.findAllById(monitorIds)) {

--- a/src/main/java/com/rackspace/salus/acm/services/AgentInstallService.java
+++ b/src/main/java/com/rackspace/salus/acm/services/AgentInstallService.java
@@ -64,6 +64,7 @@ public class AgentInstallService {
   private final ResourceApi resourceApi;
   private final BoundEventSender boundEventSender;
   private final String labelMatchQuery;
+  private final String labelMatchORQuery;
 
   @Autowired
   public AgentInstallService(JdbcTemplate jdbcTemplate,
@@ -81,6 +82,7 @@ public class AgentInstallService {
     this.resourceApi = resourceApi;
     this.boundEventSender = boundEventSender;
     labelMatchQuery = SpringResourceUtils.readContent("sql-queries/agent_installs_label_matching_query.sql");
+    labelMatchORQuery = SpringResourceUtils.readContent("sql-queries/agent_installs_label_matching_OR_query.sql");
   }
 
   public AgentInstall install(String tenantId, AgentInstallCreate in) {
@@ -198,6 +200,14 @@ public class AgentInstallService {
     final List<UUID> monitorIds = namedParameterTemplate.query(String.format(labelMatchQuery, builder.toString()), paramSource,
         (resultSet, rowIndex) -> UUID.fromString(resultSet.getString(1))
     );
+
+    final List<UUID> monitorOrIds = namedParameterTemplate.query(String.format(labelMatchORQuery, builder.toString()), paramSource,
+        (resultSet, rowIndex) -> UUID.fromString(resultSet.getString(1))
+    );
+
+    monitorIds.addAll(monitorOrIds);
+
+    //combine the lists of UUID's here
 
     // use JPA to retrieve and resolve the entities and then convert Iterable result to list
     final ArrayList<AgentInstall> results = new ArrayList<>();

--- a/src/main/java/com/rackspace/salus/acm/services/AgentInstallService.java
+++ b/src/main/java/com/rackspace/salus/acm/services/AgentInstallService.java
@@ -21,7 +21,6 @@ import com.rackspace.salus.common.util.SpringResourceUtils;
 import com.rackspace.salus.telemetry.entities.AgentInstall;
 import com.rackspace.salus.telemetry.entities.AgentRelease;
 import com.rackspace.salus.telemetry.entities.BoundAgentInstall;
-import com.rackspace.salus.telemetry.model.LabelSelectorMethod;
 import com.rackspace.salus.telemetry.repositories.AgentInstallRepository;
 import com.rackspace.salus.telemetry.repositories.AgentReleaseRepository;
 import com.rackspace.salus.telemetry.repositories.BoundAgentInstallRepository;
@@ -170,9 +169,9 @@ public class AgentInstallService {
     }
   }
 
-  List<AgentInstall> getInstallsFromLabels(String tenantId, Map<String, String> labels)
+  List<AgentInstall> getInstallsFromResourceLabels(String tenantId, Map<String, String> resourceLabels)
       throws IllegalArgumentException {
-    if (labels.size() == 0) {
+    if (resourceLabels.size() == 0) {
       throw new IllegalArgumentException("Labels must be provided for search");
     }
 
@@ -180,7 +179,7 @@ public class AgentInstallService {
     paramSource.addValue("tenantId", tenantId);
     StringBuilder builder = new StringBuilder();
     int i = 0;
-    for (Map.Entry<String, String> entry : labels.entrySet()) {
+    for (Map.Entry<String, String> entry : resourceLabels.entrySet()) {
       if (i > 0) {
         builder.append(" OR ");
       }
@@ -315,7 +314,7 @@ public class AgentInstallService {
     // ...so group them first by agent type
     final LinkedMultiValueMap<AgentType, AgentInstall> grouped = new LinkedMultiValueMap<>();
     for (AgentInstall agentInstall :
-        getInstallsFromLabels(resource.getTenantId(), resource.getLabels())) {
+        getInstallsFromResourceLabels(resource.getTenantId(), resource.getLabels())) {
       grouped.add(agentInstall.getAgentRelease().getType(), agentInstall);
     }
 

--- a/src/main/java/com/rackspace/salus/acm/web/model/AgentInstallCreate.java
+++ b/src/main/java/com/rackspace/salus/acm/web/model/AgentInstallCreate.java
@@ -16,6 +16,7 @@
 
 package com.rackspace.salus.acm.web.model;
 
+import com.rackspace.salus.telemetry.model.LabelSelectorMethod;
 import java.util.Map;
 import java.util.UUID;
 import javax.validation.constraints.NotNull;
@@ -29,4 +30,7 @@ public class AgentInstallCreate {
 
   @NotNull
   Map<String, String> labelSelector;
+
+  @NotNull
+  LabelSelectorMethod labelSelectorMethod;
 }

--- a/src/main/java/com/rackspace/salus/acm/web/model/AgentInstallDTO.java
+++ b/src/main/java/com/rackspace/salus/acm/web/model/AgentInstallDTO.java
@@ -18,6 +18,7 @@ package com.rackspace.salus.acm.web.model;
 
 import com.fasterxml.jackson.annotation.JsonView;
 import com.rackspace.salus.telemetry.entities.AgentInstall;
+import com.rackspace.salus.telemetry.model.LabelSelectorMethod;
 import com.rackspace.salus.telemetry.model.View;
 import java.time.format.DateTimeFormatter;
 import java.util.Map;
@@ -37,6 +38,8 @@ public class AgentInstallDTO {
 
   Map<String, String> labelSelector;
 
+  LabelSelectorMethod labelSelectorMethod;
+
   String createdTimestamp;
   String updatedTimestamp;
 
@@ -47,5 +50,6 @@ public class AgentInstallDTO {
     this.labelSelector = agentInstall.getLabelSelector();
     this.createdTimestamp = DateTimeFormatter.ISO_INSTANT.format(agentInstall.getCreatedTimestamp());
     this.updatedTimestamp = DateTimeFormatter.ISO_INSTANT.format(agentInstall.getUpdatedTimestamp());
+    this.labelSelectorMethod = agentInstall.getLabelSelectorMethod();
   }
 }

--- a/src/main/resources/sql-queries/agent_installs_label_matching_OR_query.sql
+++ b/src/main/resources/sql-queries/agent_installs_label_matching_OR_query.sql
@@ -1,44 +1,31 @@
-SELECT
-   agent_installs.id
-FROM
-   agent_installs JOIN agent_install_label_selectors AS ail
-WHERE
-   agent_installs.id = ail.agent_install_id
-   AND agent_installs.label_selector_method = 'OR'
-   AND agent_installs.id IN
-   (
-      SELECT
-         agent_install_id
-      FROM
-         agent_install_label_selectors
-      WHERE agent_installs.id IN
-         (
-            SELECT
-               id
-            FROM
-               agent_installs
-            WHERE
-               tenant_id = :tenantId
-         )
-         AND agent_installs.id IN
-         (
-            SELECT
-               search_labels.agent_install_id
-            FROM
-                (
-                   SELECT
-                      agent_install_id,
-                      COUNT(*) AS count
-                   FROM
-                      agent_install_label_selectors
-                   WHERE %s
-                   GROUP BY agent_install_id
-                )
-                AS search_labels
-            WHERE
-               search_labels.count >= 1
-            GROUP BY search_labels.agent_install_id
-         )
-   )
-ORDER BY
-   agent_installs.id
+SELECT agent_installs.id
+FROM   agent_installs JOIN agent_install_label_selectors AS ail
+WHERE  agent_installs.id = ail.agent_install_id
+AND agent_installs.label_selector_method = 'OR'
+AND agent_installs.id IN
+(
+  SELECT ails.agent_install_id
+  FROM   agent_install_label_selectors AS ails
+  WHERE  agent_installs.id IN
+  (
+    SELECT ai.id
+    FROM   agent_installs AS ai
+    WHERE  ai.tenant_id = :tenantId
+  )
+  AND    agent_installs.id IN
+  (
+    SELECT   search_labels.agent_install_id
+    FROM
+      (
+        SELECT  inner_ails.agent_install_id,
+          COUNT(*) AS count
+        FROM     agent_install_label_selectors AS inner_ails
+        WHERE    %s
+        GROUP BY inner_ails.agent_install_id
+      )
+      AS     search_labels
+    WHERE    search_labels.count >= 1
+    GROUP BY search_labels.agent_install_id
+  )
+)
+ORDER BY agent_installs.id

--- a/src/main/resources/sql-queries/agent_installs_label_matching_OR_query.sql
+++ b/src/main/resources/sql-queries/agent_installs_label_matching_OR_query.sql
@@ -1,0 +1,44 @@
+SELECT
+   agent_installs.id
+FROM
+   agent_installs JOIN agent_install_label_selectors AS ail
+WHERE
+   agent_installs.id = ail.agent_install_id
+   AND agent_installs.label_selector_method = 'OR'
+   AND agent_installs.id IN
+   (
+      SELECT
+         agent_install_id
+      FROM
+         agent_install_label_selectors
+      WHERE agent_installs.id IN
+         (
+            SELECT
+               id
+            FROM
+               agent_installs
+            WHERE
+               tenant_id = :tenantId
+         )
+         AND agent_installs.id IN
+         (
+            SELECT
+               search_labels.agent_install_id
+            FROM
+                (
+                   SELECT
+                      agent_install_id,
+                      COUNT(*) AS count
+                   FROM
+                      agent_install_label_selectors
+                   WHERE %s
+                   GROUP BY agent_install_id
+                )
+                AS search_labels
+            WHERE
+               search_labels.count >= 1
+            GROUP BY search_labels.agent_install_id
+         )
+   )
+ORDER BY
+   agent_installs.id

--- a/src/main/resources/sql-queries/agent_installs_label_matching_OR_query.sql
+++ b/src/main/resources/sql-queries/agent_installs_label_matching_OR_query.sql
@@ -14,18 +14,11 @@ AND agent_installs.id IN
   )
   AND    agent_installs.id IN
   (
-    SELECT   search_labels.agent_install_id
-    FROM
-      (
-        SELECT  inner_ails.agent_install_id,
-          COUNT(*) AS count
-        FROM     agent_install_label_selectors AS inner_ails
-        WHERE    %s
-        GROUP BY inner_ails.agent_install_id
-      )
-      AS     search_labels
-    WHERE    search_labels.count >= 1
-    GROUP BY search_labels.agent_install_id
+    SELECT  inner_ails.agent_install_id
+    FROM     agent_install_label_selectors AS inner_ails
+    WHERE    %s
+    GROUP BY inner_ails.agent_install_id
+    HAVING COUNT(*) >= 1
   )
 )
 ORDER BY agent_installs.id

--- a/src/main/resources/sql-queries/agent_installs_label_matching_query.sql
+++ b/src/main/resources/sql-queries/agent_installs_label_matching_query.sql
@@ -1,56 +1,41 @@
-SELECT
-   agent_installs.id
-FROM
-   agent_installs JOIN agent_install_label_selectors AS ail
-WHERE
-   agent_installs.id = ail.agent_install_id
-   AND agent_installs.label_selector_method = 'AND'
-   AND agent_installs.id IN
-   (
-      SELECT
-         agent_install_id
-      FROM
-         agent_install_label_selectors
-      WHERE agent_installs.id IN
-         (
-            SELECT
-               id
-            FROM
-               agent_installs
-            WHERE
-               tenant_id = :tenantId
-         )
-         AND agent_installs.id IN
-         (
-            SELECT
-               search_labels.agent_install_id
-            FROM
-               (
-                  SELECT
-                     agent_install_id,
-                     COUNT(*) AS count
-                  FROM
-                     agent_install_label_selectors
-                  GROUP BY
-                     agent_install_id
-               )
-               AS total_labels
-               JOIN
-                  (
-                     SELECT
-                        agent_install_id,
-                        COUNT(*) AS count
-                     FROM
-                        agent_install_label_selectors
-                     WHERE %s
-                     GROUP BY agent_install_id
-                  )
-                  AS search_labels
-            WHERE
-               total_labels.agent_install_id = search_labels.agent_install_id
-               AND search_labels.count >= total_labels.count
-            GROUP BY search_labels.agent_install_id
-         )
-   )
-ORDER BY
-   agent_installs.id
+SELECT agent_installs.id
+FROM   agent_installs
+JOIN   agent_install_label_selectors AS ail
+WHERE  agent_installs.id = ail.agent_install_id
+AND    agent_installs.label_selector_method = 'AND'
+AND    agent_installs.id IN
+(
+  SELECT agent_install_id
+  FROM   agent_install_label_selectors
+  WHERE  agent_installs.id IN
+  (
+    SELECT id
+    FROM   agent_installs
+    WHERE  tenant_id = :tenantId
+  )
+  AND    agent_installs.id IN
+  (
+    SELECT search_labels.agent_install_id
+    FROM
+    (
+      SELECT   agent_install_id,
+         COUNT(*) AS count
+      FROM     agent_install_label_selectors
+      GROUP BY agent_install_id
+    )
+    AS total_labels
+    JOIN
+    (
+      SELECT   agent_install_id,
+        COUNT(*) AS count
+      FROM     agent_install_label_selectors
+      WHERE    %s
+      GROUP BY agent_install_id
+    )
+    AS search_labels
+    WHERE    total_labels.agent_install_id = search_labels.agent_install_id
+    AND      search_labels.count >= total_labels.count
+    GROUP BY search_labels.agent_install_id
+  )
+)
+ORDER BY agent_installs.id

--- a/src/main/resources/sql-queries/agent_installs_label_matching_query.sql
+++ b/src/main/resources/sql-queries/agent_installs_label_matching_query.sql
@@ -4,6 +4,7 @@ FROM
    agent_installs JOIN agent_install_label_selectors AS ail
 WHERE
    agent_installs.id = ail.agent_install_id
+   AND agent_installs.label_selector_method = 'AND'
    AND agent_installs.id IN
    (
       SELECT

--- a/src/test/java/com/rackspace/salus/acm/services/AgentInstallServiceTest.java
+++ b/src/test/java/com/rackspace/salus/acm/services/AgentInstallServiceTest.java
@@ -133,7 +133,15 @@ public class AgentInstallServiceTest {
     // different tenant
     final AgentInstall install5 = saveInstall(
         release1, "t-2", LabelSelectorMethod.AND, "os", "linux", "cluster", "prod");
-
+    // different LabelSelectorMethod - same labels
+    final AgentInstall install6 = saveInstall(
+        release1, "t-1", LabelSelectorMethod.OR, "os", "windows", "cluster", "prod");
+    // different labelSelectorMethod - no matching labels
+    final AgentInstall install7 = saveInstall(
+        release1, "t-1", LabelSelectorMethod.OR, "os", "windows", "cluster", "staging");
+    // different labelSelectorMethod - only one label
+    final AgentInstall install8 = saveInstall(
+        release1, "t-1", LabelSelectorMethod.OR, "os", "linux");
     {
       // typical case
       Map<String, String> resourceLabels = new HashMap<>();
@@ -148,7 +156,7 @@ public class AgentInstallServiceTest {
           .map(AgentInstall::getId)
           .collect(Collectors.toList());
       assertThat(installIds).containsExactlyInAnyOrder(
-          install1.getId(), install2.getId(), install3.getId()
+          install1.getId(), install2.getId(), install3.getId(), install6.getId(), install8.getId()
       );
     }
 
@@ -184,7 +192,7 @@ public class AgentInstallServiceTest {
           .map(AgentInstall::getId)
           .collect(Collectors.toList());
       assertThat(installIds).containsExactlyInAnyOrder(
-          install4.getId()
+          install4.getId(), install8.getId()
       );
     }
 
@@ -201,24 +209,7 @@ public class AgentInstallServiceTest {
           .map(AgentInstall::getId)
           .collect(Collectors.toList());
       assertThat(installIds).containsExactlyInAnyOrder(
-          install1.getId(), install2.getId(), install3.getId()
-      );
-    }
-
-    {
-      // equal label count
-      Map<String, String> resourceLabels = new HashMap<>();
-      resourceLabels.put("os", "linux");
-      resourceLabels.put("cluster", "prod");
-
-      final List<AgentInstall> matches = agentInstallService
-          .getInstallsFromLabels("t-1", resourceLabels);
-
-      final List<UUID> installIds = matches.stream()
-          .map(AgentInstall::getId)
-          .collect(Collectors.toList());
-      assertThat(installIds).containsExactlyInAnyOrder(
-          install1.getId(), install2.getId(), install3.getId()
+          install1.getId(), install2.getId(), install3.getId(), install6.getId(), install8.getId()
       );
     }
 
@@ -243,7 +234,12 @@ public class AgentInstallServiceTest {
       final List<AgentInstall> matches = agentInstallService
           .getInstallsFromLabels("t-1", resourceLabels);
 
-      assertThat(matches).isEmpty();
+      final List<UUID> installIds = matches.stream()
+          .map(AgentInstall::getId)
+          .collect(Collectors.toList());
+      assertThat(installIds).containsExactlyInAnyOrder(
+          install8.getId()
+      );
     }
   }
 

--- a/src/test/java/com/rackspace/salus/acm/services/AgentInstallServiceTest.java
+++ b/src/test/java/com/rackspace/salus/acm/services/AgentInstallServiceTest.java
@@ -150,7 +150,7 @@ public class AgentInstallServiceTest {
       resourceLabels.put("cluster", "prod");
 
       final List<AgentInstall> matches = agentInstallService
-          .getInstallsFromLabels("t-1", resourceLabels);
+          .getInstallsFromResourceLabels("t-1", resourceLabels);
 
       final List<UUID> installIds = matches.stream()
           .map(AgentInstall::getId)
@@ -168,7 +168,7 @@ public class AgentInstallServiceTest {
       resourceLabels.put("cluster", "prod");
 
       final List<AgentInstall> matches = agentInstallService
-          .getInstallsFromLabels("t-2", resourceLabels);
+          .getInstallsFromResourceLabels("t-2", resourceLabels);
 
       final List<UUID> installIds = matches.stream()
           .map(AgentInstall::getId)
@@ -186,7 +186,7 @@ public class AgentInstallServiceTest {
       resourceLabels.put("cluster", "dev");
 
       final List<AgentInstall> matches = agentInstallService
-          .getInstallsFromLabels("t-1", resourceLabels);
+          .getInstallsFromResourceLabels("t-1", resourceLabels);
 
       final List<UUID> installIds = matches.stream()
           .map(AgentInstall::getId)
@@ -203,7 +203,7 @@ public class AgentInstallServiceTest {
       resourceLabels.put("cluster", "prod");
 
       final List<AgentInstall> matches = agentInstallService
-          .getInstallsFromLabels("t-1", resourceLabels);
+          .getInstallsFromResourceLabels("t-1", resourceLabels);
 
       final List<UUID> installIds = matches.stream()
           .map(AgentInstall::getId)
@@ -221,7 +221,7 @@ public class AgentInstallServiceTest {
       resourceLabels.put("cluster", "prod");
 
       final List<AgentInstall> matches = agentInstallService
-          .getInstallsFromLabels("t-other", resourceLabels);
+          .getInstallsFromResourceLabels("t-other", resourceLabels);
 
       assertThat(matches).isEmpty();
     }
@@ -232,7 +232,7 @@ public class AgentInstallServiceTest {
       resourceLabels.put("os", "linux");
 
       final List<AgentInstall> matches = agentInstallService
-          .getInstallsFromLabels("t-1", resourceLabels);
+          .getInstallsFromResourceLabels("t-1", resourceLabels);
 
       final List<UUID> installIds = matches.stream()
           .map(AgentInstall::getId)

--- a/src/test/java/com/rackspace/salus/acm/services/AgentReleaseServiceTest.java
+++ b/src/test/java/com/rackspace/salus/acm/services/AgentReleaseServiceTest.java
@@ -23,6 +23,7 @@ import static org.assertj.core.api.Assertions.fail;
 
 import com.rackspace.salus.telemetry.entities.AgentInstall;
 import com.rackspace.salus.telemetry.entities.AgentRelease;
+import com.rackspace.salus.telemetry.model.LabelSelectorMethod;
 import com.rackspace.salus.telemetry.repositories.AgentInstallRepository;
 import com.rackspace.salus.telemetry.repositories.AgentReleaseRepository;
 import com.rackspace.salus.acm.web.model.AgentReleaseCreate;
@@ -118,7 +119,7 @@ public class AgentReleaseServiceTest {
   public void testDelete_stillReferenced() {
     final AgentRelease release = saveRelease("1.11.0", TELEGRAF, singletonMap("os", "linux"));
 
-    saveInstall(release, "t-1", "os", "linux");
+    saveInstall(release, "t-1", LabelSelectorMethod.AND, "os", "linux");
 
     try {
       agentReleaseService.delete(release.getId());
@@ -145,7 +146,7 @@ public class AgentReleaseServiceTest {
     agentReleaseRepository.deleteAll();
   }
 
-  private AgentInstall saveInstall(AgentRelease release, String tenantId,
+  private AgentInstall saveInstall(AgentRelease release, String tenantId, LabelSelectorMethod labelSelectorMethod,
                                    String... labelPairs) {
     final Map<String, String> labelSelector = new HashMap<>();
     for (int i = 2; i <= labelPairs.length; i += 2) {
@@ -157,6 +158,7 @@ public class AgentReleaseServiceTest {
             .setAgentRelease(release)
             .setTenantId(tenantId)
             .setLabelSelector(labelSelector)
+            .setLabelSelectorMethod(LabelSelectorMethod.AND)
     );
   }
 

--- a/src/test/java/com/rackspace/salus/acm/services/AgentReleaseServiceTest.java
+++ b/src/test/java/com/rackspace/salus/acm/services/AgentReleaseServiceTest.java
@@ -158,7 +158,7 @@ public class AgentReleaseServiceTest {
             .setAgentRelease(release)
             .setTenantId(tenantId)
             .setLabelSelector(labelSelector)
-            .setLabelSelectorMethod(LabelSelectorMethod.AND)
+            .setLabelSelectorMethod(labelSelectorMethod)
     );
   }
 

--- a/src/test/java/com/rackspace/salus/acm/web/controller/AgentInstallControllerTest.java
+++ b/src/test/java/com/rackspace/salus/acm/web/controller/AgentInstallControllerTest.java
@@ -156,6 +156,35 @@ public class AgentInstallControllerTest {
   }
 
   @Test
+  public void testCreateWithOr() throws Exception {
+    final AgentRelease release = populateRelease();
+    final AgentInstall install = populateInstall(release);
+
+    when(agentInstallService.install(any(), any()))
+        .thenReturn(install);
+
+    mockMvc.perform(
+        post("/api/tenant/{tenantId}/agent-installs", "t-1")
+            .accept(MediaType.APPLICATION_JSON)
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(
+                JsonTestUtils.readContent("AgentInstallControllerTest/agent_install_create_with_or.json")))
+        .andExpect(status().isCreated())
+        .andExpect(content().json(
+            // id field should not be returned
+            readContent("AgentInstallControllerTest/agent_install_response.json"), true));
+
+    verify(agentInstallService).install("t-1", new AgentInstallCreate()
+        .setAgentReleaseId(release.getId())
+        .setLabelSelector(Collections.singletonMap("os", "linux"))
+        .setLabelSelectorMethod(LabelSelectorMethod.OR)
+    );
+
+    verifyNoMoreInteractions(
+        boundAgentInstallRepository, agentInstallRepository, agentInstallService);
+  }
+
+  @Test
   public void testDelete() throws Exception {
     final AgentRelease release = populateRelease();
     final AgentInstall install = populateInstall(release);

--- a/src/test/java/com/rackspace/salus/acm/web/controller/AgentInstallControllerTest.java
+++ b/src/test/java/com/rackspace/salus/acm/web/controller/AgentInstallControllerTest.java
@@ -31,6 +31,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import com.rackspace.salus.telemetry.entities.AgentInstall;
 import com.rackspace.salus.telemetry.entities.AgentRelease;
 import com.rackspace.salus.telemetry.entities.BoundAgentInstall;
+import com.rackspace.salus.telemetry.model.LabelSelectorMethod;
 import com.rackspace.salus.telemetry.repositories.AgentInstallRepository;
 import com.rackspace.salus.telemetry.repositories.BoundAgentInstallRepository;
 import com.rackspace.salus.acm.services.AgentInstallService;
@@ -147,6 +148,7 @@ public class AgentInstallControllerTest {
     verify(agentInstallService).install("t-1", new AgentInstallCreate()
         .setAgentReleaseId(release.getId())
         .setLabelSelector(Collections.singletonMap("os", "linux"))
+        .setLabelSelectorMethod(LabelSelectorMethod.AND)
     );
 
     verifyNoMoreInteractions(
@@ -188,6 +190,7 @@ public class AgentInstallControllerTest {
     return new AgentInstall()
         .setId(UUID.fromString("00000000-0000-0000-0002-000000000000"))
         .setLabelSelector(singletonMap("os", "linux"))
+        .setLabelSelectorMethod(LabelSelectorMethod.AND)
         .setTenantId("t-1")
         .setCreatedTimestamp(Instant.ofEpochSecond(100002))
         .setUpdatedTimestamp(Instant.ofEpochSecond(100003))

--- a/src/test/resources/AgentInstallControllerTest/agent_install_create.json
+++ b/src/test/resources/AgentInstallControllerTest/agent_install_create.json
@@ -2,5 +2,6 @@
   "agentReleaseId": "00000000-0000-0000-0001-000000000000",
   "labelSelector": {
     "os": "linux"
-  }
+  },
+  "labelSelectorMethod": "AND"
 }

--- a/src/test/resources/AgentInstallControllerTest/agent_install_create_with_or.json
+++ b/src/test/resources/AgentInstallControllerTest/agent_install_create_with_or.json
@@ -1,0 +1,7 @@
+{
+  "agentReleaseId": "00000000-0000-0000-0001-000000000000",
+  "labelSelector": {
+    "os": "linux"
+  },
+  "labelSelectorMethod": "OR"
+}

--- a/src/test/resources/AgentInstallControllerTest/agent_install_response.json
+++ b/src/test/resources/AgentInstallControllerTest/agent_install_response.json
@@ -15,6 +15,7 @@
   "labelSelector": {
     "os": "linux"
   },
+  "labelSelectorMethod": "AND",
   "createdTimestamp": "1970-01-02T03:46:42Z",
   "updatedTimestamp": "1970-01-02T03:46:43Z"
 }

--- a/src/test/resources/AgentInstallControllerTest/agent_install_response_paged.json
+++ b/src/test/resources/AgentInstallControllerTest/agent_install_response_paged.json
@@ -17,6 +17,7 @@
       "labelSelector": {
         "os": "linux"
       },
+      "labelSelectorMethod": "AND",
       "createdTimestamp": "1970-01-02T03:46:42Z",
       "updatedTimestamp": "1970-01-02T03:46:43Z"
     }

--- a/src/test/resources/AgentInstallControllerTest/single_install_binding.json
+++ b/src/test/resources/AgentInstallControllerTest/single_install_binding.json
@@ -18,6 +18,7 @@
     "labelSelector": {
       "os": "linux"
     },
+    "labelSelectorMethod": "AND",
     "createdTimestamp": "1970-01-02T03:46:42Z",
     "updatedTimestamp": "1970-01-02T03:46:43Z"
   }


### PR DESCRIPTION
# Resolves

SALUS-606

# What

Adds the logical OR operator to agent catalog management so that we can replicate the same results in this service as what will happen in resource management for both logical operators.

# How

It adds the query here and does the same logic the monitor management is doing

## How to test

Run the unit tests. 

# Why

This was the same way we handled this in other services

