### PR TITLE
Added console appender to production block of logback config

### DIFF
--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright 2019 Rackspace US, Inc.
+  ~ Copyright 2020 Rackspace US, Inc.
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.
@@ -27,6 +27,7 @@
   <root level="INFO">
     <springProfile name="production">
       <appender-ref ref="FLUENCY" />
+      <appender-ref ref="CONSOLE"/>
     </springProfile>
     <springProfile name="!production">
       <appender-ref ref="CONSOLE"/>


### PR DESCRIPTION
# What

When there are fluent or low level config issues similar to that, then it is hard to debug logs when they might just go into bitbucket.

# How

Add console appender to the active profile block for `production`.