### PR TITLE
Enable tenant id verification

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -60,6 +60,18 @@
       <artifactId>spring-boot-starter-data-jpa</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-cache</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>javax.cache</groupId>
+      <artifactId>cache-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.ehcache</groupId>
+      <artifactId>ehcache</artifactId>
+    </dependency>
+    <dependency>
       <groupId>mysql</groupId>
       <artifactId>mysql-connector-java</artifactId>
       <scope>runtime</scope>

--- a/src/main/java/com/rackspace/salus/acm/TelemetryAgentCatalogManagementApplication.java
+++ b/src/main/java/com/rackspace/salus/acm/TelemetryAgentCatalogManagementApplication.java
@@ -16,10 +16,12 @@
 
 package com.rackspace.salus.acm;
 
+import com.rackspace.salus.common.config.AutoConfigureSalusAppMetrics;
 import com.rackspace.salus.common.messaging.EnableSalusKafkaMessaging;
 import com.rackspace.salus.common.util.DumpConfigProperties;
 import com.rackspace.salus.common.web.EnableExtendedErrorAttributes;
 import com.rackspace.salus.common.web.EnableRoleBasedJsonViews;
+import com.rackspace.salus.telemetry.web.EnableTenantVerification;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 
@@ -27,6 +29,8 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 @EnableSalusKafkaMessaging
 @EnableExtendedErrorAttributes
 @EnableRoleBasedJsonViews
+@EnableTenantVerification
+@AutoConfigureSalusAppMetrics
 public class TelemetryAgentCatalogManagementApplication {
 
   public static void main(String[] args) {


### PR DESCRIPTION
See https://github.com/racker/salus-telemetry-model/pull/124

Utilizes the `@EnableTenantVerification` annotations and adds some simple tests to show it took effect.